### PR TITLE
Update com.obsproject.Studio.Plugin.LiveStreamSegmenter.json

### DIFF
--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveStreamSegmenter.json
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveStreamSegmenter.json
@@ -11,6 +11,23 @@
   },
   "modules": [
     {
+      "name": "nlohmann-json",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_INSTALL_INCLUDEDIR=include"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/nlohmann/json.git",
+          "tag": "v3.12.0",
+          "commit": "55f93686c01528224f448c19128836e7df245f72"
+        }
+      ]
+    },
+    {
       "name": "live-stream-segmenter",
       "buildsystem": "cmake-ninja",
       "builddir": true,
@@ -25,8 +42,8 @@
         {
           "type": "git",
           "url": "https://github.com/kaito-tokyo/live-stream-segmenter.git",
-          "tag": "0.1.1",
-          "commit": "9a202c5aa8d88b6bcaf9ec90d970fb989b099cfb",
+          "tag": "2.6.0",
+          "commit": "1ebe79d373b0249025b73c579d736c3dd2d6fd11",
           "x-checker-data": {
             "type": "git",
             "tag-pattern": "^([\\d.]+)$"


### PR DESCRIPTION
This pull request updates the Flatpak build manifest for the LiveStreamSegmenter OBS plugin to improve dependency management and update the plugin source. The most important changes are the addition of a new dependency and an update to the plugin version.

**Dependency management:**

* Added a new module for the `nlohmann-json` library, specifying its source and build configuration, to ensure the plugin has the required JSON support.

**Plugin source update:**

* Updated the `live-stream-segmenter` module to use version `2.6.0` (previously `0.1.1`) and the corresponding commit, ensuring the build uses the latest features and fixes from upstream.