### PR TITLE
Update unsupported-build.yaml

### DIFF
--- a/.github/workflows/unsupported-build.yaml
+++ b/.github/workflows/unsupported-build.yaml
@@ -82,6 +82,6 @@ jobs:
       - name: Build Flatpak
         uses: flatpak/flatpak-github-actions/flatpak-builder@10a3c29f0162516f0f68006be14c92f34bd4fa6c
         with:
-          bundle: com.obsproject.Studio.Plugin.live-stream-segmenter
-          manifest-path: unsupported/flatpak/com.obsproject.Studio.Plugin.live-stream-segmenter.json
+          bundle: com.obsproject.Studio.Plugin.LiveStreamSegmenter
+          manifest-path: unsupported/flatpak/com.obsproject.Studio.Plugin.LiveStreamSegmenter.json
           cache-key: flatpak-builder-${{ github.sha }}


### PR DESCRIPTION
This pull request makes a minor update to the Flatpak build configuration in the GitHub Actions workflow. The change corrects the casing in both the Flatpak bundle name and manifest path to match the proper naming convention.

* Updated the `bundle` and `manifest-path` values in `.github/workflows/unsupported-build.yaml` to use `LiveStreamSegmenter` instead of `live-stream-segmenter`, ensuring consistency in naming.