### PR TITLE
Update com.obsproject.Studio.Plugin.LiveStreamSegmenter.json

### DIFF
--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveStreamSegmenter.json
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveStreamSegmenter.json
@@ -42,8 +42,8 @@
         {
           "type": "git",
           "url": "https://github.com/kaito-tokyo/live-stream-segmenter.git",
-          "tag": "2.6.0",
-          "commit": "1ebe79d373b0249025b73c579d736c3dd2d6fd11",
+          "tag": "0.1.1",
+          "commit": "9a202c5aa8d88b6bcaf9ec90d970fb989b099cfb",
           "x-checker-data": {
             "type": "git",
             "tag-pattern": "^([\\d.]+)$"


### PR DESCRIPTION
This pull request updates the `live-stream-segmenter` dependency in the Flatpak manifest for the OBS Studio LiveStreamSegmenter plugin, rolling it back to an earlier version.

Dependency update:

* Rolled back the `live-stream-segmenter` git source in `com.obsproject.Studio.Plugin.LiveStreamSegmenter.json` from tag `2.6.0` (commit `1ebe79d...`) to tag `0.1.1` (commit `9a202c5...`).