### PR TITLE
Update com.obsproject.Studio.Plugin.LiveStreamSegmenter.json

### DIFF
--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveStreamSegmenter.json
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveStreamSegmenter.json
@@ -16,7 +16,8 @@
       "builddir": true,
       "config-opts": [
         "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_INCLUDEDIR=include"
+        "-DCMAKE_INSTALL_INCLUDEDIR=include",
+        "-DJSON_BuildTests=OFF"
       ],
       "sources": [
         {


### PR DESCRIPTION
This pull request makes a minor update to the build configuration for the Flatpak manifest of the LiveStreamSegmenter plugin. The change disables the building of tests during the CMake configuration, which can help speed up the build process and reduce unnecessary artifacts.

- Build configuration:
  * Added the `-DJSON_BuildTests=OFF` option to the `config-opts` array in `com.obsproject.Studio.Plugin.LiveStreamSegmenter.json` to disable building tests.