### PR TITLE
Add MIT license header to YouTube API client files

### DIFF
--- a/src/LiveStreamSegmenter/API/YouTubeApiClient.cpp
+++ b/src/LiveStreamSegmenter/API/YouTubeApiClient.cpp
@@ -1,8 +1,29 @@
-#include "YouTubeApiClient.hpp"
-#include <iostream>
-#include <sstream> // エラーメッセージ構築用
+/*
+ * MIT License
+ * 
+ * Copyright (c) 2025 Kaito Udagawa
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
 
-// 外部ライブラリ
+#include "YouTubeApiClient.hpp"
+
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
 

--- a/src/LiveStreamSegmenter/API/YouTubeApiClient.hpp
+++ b/src/LiveStreamSegmenter/API/YouTubeApiClient.hpp
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ * 
+ * Copyright (c) 2025 Kaito Udagawa
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+
 #pragma once
 
 #include <functional>

--- a/src/LiveStreamSegmenter/API/YouTubeTypes.hpp
+++ b/src/LiveStreamSegmenter/API/YouTubeTypes.hpp
@@ -1,4 +1,3 @@
-
 /*
  * MIT License
  * 
@@ -49,18 +48,6 @@ struct YouTubeStreamKey {
 	std::string cdn_ingestionInfo_streamName;
 	std::string cdn_ingestionInfo_ingestionAddress;
 	std::string cdn_ingestionInfo_backupIngestionAddress;
-};
-
-/**
- * @brief Parameters for creating or updating a YouTube broadcast.
- * Includes title, description, scheduled start time, and privacy status.
- */
-struct YouTubeBroadcastParams {
-	YouTubeBroadcastParams() : privacyStatus("private") {}
-	std::string title;
-	std::string description;
-	std::string scheduledStartTime;
-	std::string privacyStatus;
 };
 
 } // namespace KaitoTokyo::LiveStreamSegmenter::API


### PR DESCRIPTION
This pull request primarily adds the MIT license header to two source files and removes an unused struct definition from the codebase. These changes improve code clarity and ensure proper licensing information is included.

**Licensing and Documentation:**
* Added the MIT license header to the top of `YouTubeApiClient.cpp` and `YouTubeApiClient.hpp` to clarify the licensing of these files. [[1]](diffhunk://#diff-3335909e473e3aae338d9c6b932f505d660ab4fbb09476df848ea9090062d45cR1-L5) [[2]](diffhunk://#diff-6e682459812d74a6cad095732ab2c059088262eb4ab761dba6978e8accb5f60bR1-R24)

**Code Cleanup:**
* Removed the unused `YouTubeBroadcastParams` struct from `YouTubeTypes.hpp` to clean up the code and reduce clutter.

**Minor Formatting:**
* Removed unnecessary blank line at the top of `YouTubeTypes.hpp` for consistency.Added the MIT license header to YouTubeApiClient.cpp and YouTubeApiClient.hpp for proper attribution and licensing. Also removed an unused struct and extra blank line from YouTubeTypes.hpp.