### PR TITLE
Update com.obsproject.Studio.Plugin.LiveStreamSegmenter.json

### DIFF
--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveStreamSegmenter.json
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveStreamSegmenter.json
@@ -11,6 +11,23 @@
   },
   "modules": [
     {
+      "name": "cpp-httplib",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_INSTALL_INCLUDEDIR=include"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/yhirose/cpp-httplib.git",
+          "tag": "v0.28.0",
+          "commit": "adf58bf474fac638160592d6c3f67da4ebc7df20"
+        }
+      ]
+    },
+    {
       "name": "nlohmann-json",
       "buildsystem": "cmake-ninja",
       "builddir": true,


### PR DESCRIPTION
This pull request adds a new build dependency to the Flatpak manifest for the LiveStreamSegmenter OBS Studio plugin. The most significant change is the inclusion of the `cpp-httplib` library as a build module, which will be fetched from its GitHub repository and built using CMake.

Dependency management:

* Added a new module for the `cpp-httplib` library to the Flatpak manifest (`com.obsproject.Studio.Plugin.LiveStreamSegmenter.json`), specifying its source, build system, and configuration options.