### PR TITLE
Update com.obsproject.Studio.Plugin.LiveStreamSegmenter.json

### DIFF
--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveStreamSegmenter.json
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveStreamSegmenter.json
@@ -11,6 +11,23 @@
   },
   "modules": [
     {
+      "name": "cpp-httplib",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_INSTALL_INCLUDEDIR=include"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/yhirose/cpp-httplib.git",
+          "tag": "v0.28.0",
+          "commit": "adf58bf474fac638160592d6c3f67da4ebc7df20"
+        }
+      ]
+    },
+    {
       "name": "nlohmann-json",
       "buildsystem": "cmake-ninja",
       "builddir": true,


### PR DESCRIPTION
This pull request adds a new dependency to the Flatpak build manifest for the LiveStreamSegmenter plugin. The main change is the inclusion of the `cpp-httplib` library, which is now built from source as part of the Flatpak build process.

Dependency management:

* Added a new module for `cpp-httplib`, specifying its source repository, version tag (`v0.28.0`), and commit hash, and configured it to build with CMake and Ninja.