### PR TITLE
Update workflow and vcpkg baselines

### DIFF
--- a/.github/workflows/unsupported-build.yaml
+++ b/.github/workflows/unsupported-build.yaml
@@ -33,7 +33,7 @@ jobs:
           useradd -m builder
           echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
           chown -R builder:builder .
-          pacman -Sy --noconfirm git
+          pacman -Syu --noconfirm git
 
       - name: Install cpp-httplib
         run: |
@@ -62,7 +62,7 @@ jobs:
           useradd -m builder
           echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
           chown -R builder:builder .
-          pacman -Sy --noconfirm git
+          pacman -Syu --noconfirm git
 
       - name: Install cpp-httplib
         run: |

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,17 +2,15 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "git",
-    "baseline": "84bab45d415d22042bd0b9081aea57f362da3f35",
+    "baseline": "cfcbdb245f1179a5a493890a0b69531d66969e62",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [
     {
       "kind": "git",
-      "baseline": "b5c4160166bdec2821954d3b6a92bfa282592972",
+      "baseline": "901fdb51caca7b97a3fb37810642dc28631ece49",
       "repository": "https://github.com/kaito-tokyo/vcpkg-obs-kaito-tokyo",
       "packages": [
-        "libpng",
-        "ncnn",
         "wolfssl"
       ]
     }


### PR DESCRIPTION
This pull request updates the system dependencies and registry baselines to ensure compatibility with the latest package versions and improve build reliability.

Dependency management updates:

* Updated the `pacman` command in `.github/workflows/unsupported-build.yaml` to use `-Syu` instead of `-Sy`, ensuring both the package database and system packages are upgraded before installing `git`. [[1]](diffhunk://#diff-01e52d94c941103b86c7c05005fcce4da3082fb2391e0a995cc88728e7477cdbL36-R36) [[2]](diffhunk://#diff-01e52d94c941103b86c7c05005fcce4da3082fb2391e0a995cc88728e7477cdbL65-R65)

Package registry configuration:

* Updated the `baseline` commit hashes for both the default vcpkg registry and the custom kaito-tokyo registry in `vcpkg-configuration.json` to newer versions, ensuring the project uses the latest package definitions.Update the GitHub Actions workflow to use 'pacman -Syu' for git installation, ensuring system packages are up to date. Also update vcpkg and custom registry baselines in vcpkg-configuration.json for dependency management.