### PR TITLE
Update GoogleTokenState.hpp

### DIFF
--- a/src/LiveStreamSegmenter/Auth/GoogleTokenState.hpp
+++ b/src/LiveStreamSegmenter/Auth/GoogleTokenState.hpp
@@ -84,8 +84,7 @@ struct GoogleTokenState {
 		expires_at.reset();
 	}
 
-	NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(GoogleTokenState, ver, access_token, refresh_token, email, scope,
-						    expires_at)
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(GoogleTokenState, ver, access_token, refresh_token, email, scope, expires_at)
 };
 
 } // namespace KaitoTokyo::LiveStreamSegmenter::Auth


### PR DESCRIPTION
This pull request makes a minor update to the serialization macro used in the `GoogleTokenState` struct. The macro for JSON serialization is changed from `NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT` to `NLOHMANN_DEFINE_TYPE_INTRUSIVE`, which may affect how default values are handled during (de)serialization. No other logic or structural changes are made.