### PR TITLE
Remove WITH_DEFAULT from nlohmann type macros

### DIFF
--- a/src/LiveStreamSegmenter/Auth/GoogleAuthResponse.hpp
+++ b/src/LiveStreamSegmenter/Auth/GoogleAuthResponse.hpp
@@ -22,8 +22,7 @@ struct GoogleTokenResponse {
 	std::optional<std::string> refresh_token;
 	std::optional<std::string> scope;
 
-	NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(GoogleTokenResponse, access_token, expires_in, token_type,
-						    refresh_token, scope)
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(GoogleTokenResponse, access_token, expires_in, token_type, refresh_token, scope)
 };
 
 } // namespace KaitoTokyo::LiveStreamSegmenter::Auth

--- a/src/LiveStreamSegmenter/Auth/GoogleOAuth2ClientCredential.hpp
+++ b/src/LiveStreamSegmenter/Auth/GoogleOAuth2ClientCredential.hpp
@@ -20,7 +20,7 @@ struct GoogleOAuth2ClientCredential {
 	std::string client_id;
 	std::string client_secret;
 
-	NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(GoogleOAuth2ClientCredential, ver, client_id, client_secret)
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(GoogleOAuth2ClientCredential, ver, client_id, client_secret)
 };
 
 } // namespace KaitoTokyo::LiveStreamSegmenter::Auth


### PR DESCRIPTION
Replaces NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT with NLOHMANN_DEFINE_TYPE_INTRUSIVE in GoogleTokenResponse and GoogleOAuth2ClientCredential structs. This change may affect how default values are handled during JSON serialization/deserialization.