### PR TITLE
Update unsupported-build.yaml

### DIFF
--- a/.github/workflows/unsupported-build.yaml
+++ b/.github/workflows/unsupported-build.yaml
@@ -34,8 +34,10 @@ jobs:
           pacman -Syu --noconfirm git
 
       - name: Install cpp-httplib
-        working-directory: ${{ runner.temp }}
+        shell: bash
+        working-directory: ${{ runner.temp }}/cpp-httplib
         run: |
+          sudo chown -R builder:builder .
           sudo -u builder git clone https://aur.archlinux.org/cpp-httplib.git
           cd cpp-httplib
           sudo -u builder makepkg -si --noconfirm
@@ -70,8 +72,10 @@ jobs:
           pacman -Syu --noconfirm git
 
       - name: Install cpp-httplib
-        working-directory: ${{ runner.temp }}
+        shell: bash
+        working-directory: ${{ runner.temp }}/cpp-httplib
         run: |
+          sudo chown -R builder:builder .
           sudo -u builder git clone https://aur.archlinux.org/cpp-httplib.git
           cd cpp-httplib
           sudo -u builder makepkg -si --noconfirm


### PR DESCRIPTION
This pull request updates the CI workflow in `.github/workflows/unsupported-build.yaml` to ensure that the `cpp-httplib` dependency is installed before building the `live-stream-segmenter` and `live-stream-segmenter-git` packages. This helps prevent build failures due to missing dependencies.

Dependency installation improvements:

* Added a step to clone and install `cpp-httplib` from the AUR before building `unsupported/arch/live-stream-segmenter`.
* Added a similar step for installing `cpp-httplib` before building `unsupported/arch/live-stream-segmenter-git`.