### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,9 +84,6 @@ elseif(USE_PKGCONFIG)
   target_compile_definitions(fmt::fmt INTERFACE ${PC_FMT_CFLAGS_OTHER})
   target_link_directories(fmt::fmt INTERFACE ${PC_FMT_LIBRARY_DIRS})
 
-  # --- httplib ---
-  find_package(httplib CONFIG REQUIRED)
-
   # --- nlohmann_json ---
   pkg_check_modules(PC_NLOHMANN_JSON REQUIRED nlohmann_json)
   add_library(nlohmann_json::nlohmann_json INTERFACE IMPORTED)


### PR DESCRIPTION
This pull request makes a minor change to the build configuration by removing the `find_package` call for `httplib` when using pkg-config. This simplifies the CMake configuration and may help avoid issues if `httplib` is not needed or managed differently.

* Build configuration cleanup:
  * Removed the `find_package(httplib CONFIG REQUIRED)` line from the `elseif(USE_PKGCONFIG)` section in `CMakeLists.txt`.