### PR TITLE
Start stream

### DIFF
--- a/src/LiveStreamSegmenter/Controller/YouTubeStreamSegmenterMainLoop.cpp
+++ b/src/LiveStreamSegmenter/Controller/YouTubeStreamSegmenterMainLoop.cpp
@@ -120,13 +120,12 @@ std::string getAccessToken(std::shared_ptr<Store::AuthStore> authStore, std::sha
 	return accessToken;
 }
 
-Async::Task<void>
-startContinuousSessionTask(std::shared_ptr<Scripting::ScriptingRuntime> runtime,
-			   std::shared_ptr<Store::AuthStore> authStore,
-			   std::shared_ptr<Store::EventHandlerStore> eventHandlerStore,
-			   std::shared_ptr<Store::YouTubeStore> youtubeStore,
-			   std::shared_ptr<const Logger::ILogger> logger,
-			   [[maybe_unused]] QWidget *parent)
+Async::Task<void> startContinuousSessionTask(std::shared_ptr<Scripting::ScriptingRuntime> runtime,
+					     std::shared_ptr<Store::AuthStore> authStore,
+					     std::shared_ptr<Store::EventHandlerStore> eventHandlerStore,
+					     std::shared_ptr<Store::YouTubeStore> youtubeStore,
+					     std::shared_ptr<const Logger::ILogger> logger,
+					     [[maybe_unused]] QWidget *parent)
 {
 	co_await AsyncQt::ResumeOnQThreadPool{QThreadPool::globalInstance()};
 


### PR DESCRIPTION
This pull request introduces enhancements to the YouTube live streaming workflow by integrating `YouTubeStore` into the `YouTubeStreamSegmenterMainLoop`, improving the process for binding live broadcasts to streams, and supporting HLS streaming setup. The changes refactor the main loop and session handling to make use of the new store and API client methods, and add robust error handling and logging.

**Integration and API Improvements:**

* The `YouTubeStreamSegmenterMainLoop` class and its main loop now accept and use a `YouTubeStore` instance, allowing access to YouTube stream information during session handling. [[1]](diffhunk://#diff-637f9bc9b7d70c3e5669f13563979626b490ea534c5873259ead192693afc0feL50-R50) [[2]](diffhunk://#diff-2c49afda626983ec88f84f379f6e351a583a0548b669c3cf93cb8775ba652bb1R36-R53) [[3]](diffhunk://#diff-f2310df3b3290b429c0d7bac5b9a29a1409d934de19cd4df762d6ce3da38892cR54) [[4]](diffhunk://#diff-f2310df3b3290b429c0d7bac5b9a29a1409d934de19cd4df762d6ce3da38892cR74) [[5]](diffhunk://#diff-f2310df3b3290b429c0d7bac5b9a29a1409d934de19cd4df762d6ce3da38892cR85)
* The `YouTubeApiClient` class now provides a `bindLiveBroadcast` method to associate a live broadcast with a stream, including error handling and logging. [[1]](diffhunk://#diff-d0feacf3355e29616b74a1e1fd2a37f88d8662d22007241d4fedf034007e54e0R380-R417) [[2]](diffhunk://#diff-b8c374fea16e429b4bd0bfdd2c19951f9df53a5d608ee46b3c421b49fe98882cR52-R54)

**Session and Streaming Logic Enhancements:**

* The session startup logic (`startContinuousSessionTask`) is refactored to use the new `YouTubeStore` for retrieving stream keys and integrates the `bindLiveBroadcast` API call for associating broadcasts and streams. [[1]](diffhunk://#diff-2c49afda626983ec88f84f379f6e351a583a0548b669c3cf93cb8775ba652bb1L89-L107) [[2]](diffhunk://#diff-2c49afda626983ec88f84f379f6e351a583a0548b669c3cf93cb8775ba652bb1R120-R151) [[3]](diffhunk://#diff-2c49afda626983ec88f84f379f6e351a583a0548b669c3cf93cb8775ba652bb1R173-R217) [[4]](diffhunk://#diff-2c49afda626983ec88f84f379f6e351a583a0548b669c3cf93cb8775ba652bb1L185-R232)
* HLS streaming support is added: when the stream ingestion type is HLS, the code now configures and starts an OBS streaming service for YouTube HLS, with appropriate logging and error handling for unsupported types.

**Utility and Include Cleanups:**

* Added a new overload of `doPost` in `YouTubeApiClient.cpp` for POST requests without a body, used by the new bind API.
* Updated includes and minor file structure adjustments to support the new dependencies and maintain code consistency. [[1]](diffhunk://#diff-2c49afda626983ec88f84f379f6e351a583a0548b669c3cf93cb8775ba652bb1R36-R53) [[2]](diffhunk://#diff-f2310df3b3290b429c0d7bac5b9a29a1409d934de19cd4df762d6ce3da38892cL31-R33)

These changes collectively improve the reliability, flexibility, and maintainability of the YouTube live streaming segmenter.