### PR TITLE
Migrate AuthStore to use QtKeychain for credential storage

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -33,7 +33,7 @@
   },
   "platformConfig": {
     "macos": {
-      "bundleId": "com.example.plugintemplate-for-obs"
+      "bundleId": "tokyo.kaito.live-stream-segmenter"
     }
   },
   "name": "live-stream-segmenter",

--- a/src/LiveStreamSegmenter/Store/AuthStore.cpp
+++ b/src/LiveStreamSegmenter/Store/AuthStore.cpp
@@ -118,7 +118,7 @@ void AuthStore::onWriteFinished(QKeychain::Job *job)
 		if (job->error()) {
 			std::string error = job->errorString().toStdString();
 			logger->error("KeychainWriteError(AuthStore::onWriteFinished)",
-				       {{"key", key}, {"error", error}});
+				      {{"key", key}, {"error", error}});
 		} else {
 			logger->info("KeychainWriteSuccess", {{"key", key}});
 		}

--- a/src/LiveStreamSegmenter/Store/AuthStore.cpp
+++ b/src/LiveStreamSegmenter/Store/AuthStore.cpp
@@ -113,14 +113,14 @@ void AuthStore::onWriteFinished(QKeychain::Job *job)
 		logger = logger_;
 	}
 
-	if (logger_) {
+	if (logger) {
 		std::string key = job->key().toStdString();
 		if (job->error()) {
 			std::string error = job->errorString().toStdString();
-			logger_->error("KeychainWriteError(AuthStore::onWriteFinished)",
+			logger->error("KeychainWriteError(AuthStore::onWriteFinished)",
 				       {{"key", key}, {"error", error}});
 		} else {
-			logger_->info("KeychainWriteSuccess", {{"key", key}});
+			logger->info("KeychainWriteSuccess", {{"key", key}});
 		}
 	}
 }

--- a/src/LiveStreamSegmenter/Store/AuthStore.cpp
+++ b/src/LiveStreamSegmenter/Store/AuthStore.cpp
@@ -23,6 +23,9 @@
 #include <fstream>
 #include <stdexcept>
 
+#include <QString>
+
+#include <qtkeychain/keychain.h>
 #include <nlohmann/json.hpp>
 
 #include <obs-frontend-api.h>
@@ -31,20 +34,15 @@
 
 namespace KaitoTokyo::LiveStreamSegmenter::Store {
 
-AuthStore::AuthStore() = default;
+namespace {
+
+const QString kKeychainService = "tokyo.kaito.live-stream-segmenter";
+
+} // anonymous namespace
+
+AuthStore::AuthStore(QObject *parent) : QObject(parent) {}
 
 AuthStore::~AuthStore() noexcept = default;
-
-std::filesystem::path AuthStore::getConfigPath()
-{
-	ObsBridgeUtils::unique_bfree_char_t profilePathRaw(obs_frontend_get_current_profile_path());
-	if (!profilePathRaw) {
-		throw std::runtime_error("GetCurrentProfilePathFailed(getConfigPath)");
-	}
-
-	std::filesystem::path profilePath(reinterpret_cast<const char8_t *>(profilePathRaw.get()));
-	return profilePath / "live-stream-segmenter_AuthStore.json";
-}
 
 void AuthStore::setLogger(std::shared_ptr<const Logger::ILogger> logger)
 {
@@ -76,10 +74,8 @@ GoogleAuth::GoogleTokenState AuthStore::getGoogleTokenState() const
 	return googleTokenState_;
 }
 
-void AuthStore::save() const
+void AuthStore::save()
 {
-	const std::filesystem::path configPath = getConfigPath();
-
 	GoogleAuth::GoogleOAuth2ClientCredentials googleOAuth2ClientCredentials;
 	GoogleAuth::GoogleTokenState googleTokenState;
 	{
@@ -88,63 +84,133 @@ void AuthStore::save() const
 		googleTokenState = googleTokenState_;
 	}
 
-	nlohmann::json j{
-		{"googleOAuth2ClientCredentials", googleOAuth2ClientCredentials},
-		{"googleTokenState", googleTokenState},
-	};
+	googleTokenState.access_token.clear();
 
-	std::filesystem::path tmpConfigPath = configPath;
-	tmpConfigPath += ".tmp";
-	std::ofstream ofs(tmpConfigPath, std::ios::out);
-	if (!ofs.is_open()) {
-		logger_->error("FileOpenError", {{"path", configPath.string()}});
-		throw std::runtime_error("FileOpenError(save)");
+	nlohmann::json jGoogleOAuth2ClientCredentials = googleOAuth2ClientCredentials;
+	nlohmann::json jGoogleTokenState = googleTokenState;
+
+	auto writeGoogleOAuth2ClientCredentialsJob = new QKeychain::WritePasswordJob(kKeychainService, this);
+	writeGoogleOAuth2ClientCredentialsJob->setAutoDelete(true);
+	writeGoogleOAuth2ClientCredentialsJob->setKey("googleOAuth2ClientCredentials");
+	writeGoogleOAuth2ClientCredentialsJob->setTextData(
+		QString::fromStdString(jGoogleOAuth2ClientCredentials.dump()));
+	connect(writeGoogleOAuth2ClientCredentialsJob, &QKeychain::Job::finished, this, &AuthStore::onWriteFinished);
+	writeGoogleOAuth2ClientCredentialsJob->start();
+
+	auto writeGoogleTokenStateJob = new QKeychain::WritePasswordJob(kKeychainService, this);
+	writeGoogleTokenStateJob->setAutoDelete(true);
+	writeGoogleTokenStateJob->setKey("googleTokenState");
+	writeGoogleTokenStateJob->setTextData(QString::fromStdString(jGoogleTokenState.dump()));
+	connect(writeGoogleTokenStateJob, &QKeychain::Job::finished, this, &AuthStore::onWriteFinished);
+	writeGoogleTokenStateJob->start();
+}
+
+void AuthStore::onWriteFinished(QKeychain::Job *job)
+{
+	if (logger_) {
+		std::string key = job->key().toStdString();
+		if (job->error()) {
+			std::string error = job->errorString().toStdString();
+			logger_->error("KeychainWriteError(AuthStore::onWriteFinished)",
+				       {{"key", key}, {"error", error}});
+		} else {
+			logger_->info("KeychainWriteSuccess", {{"key", key}});
+		}
 	}
-
-	ofs << j;
-
-	ofs.close();
-
-	std::filesystem::path bakConfigPath = configPath;
-	bakConfigPath += ".bak";
-
-	if (std::filesystem::is_regular_file(configPath)) {
-		std::filesystem::rename(configPath, bakConfigPath);
-	}
-	std::filesystem::rename(tmpConfigPath, configPath);
 }
 
 void AuthStore::restore()
 {
-	const std::filesystem::path configPath = getConfigPath();
-	if (!std::filesystem::is_regular_file(configPath)) {
-		logger_->info("AuthStoreConfigFileNotExist", {{"path", configPath.string()}});
+	auto readGoogleOAuth2ClientCredentialsJob = new QKeychain::ReadPasswordJob(kKeychainService, this);
+	readGoogleOAuth2ClientCredentialsJob->setAutoDelete(true);
+	readGoogleOAuth2ClientCredentialsJob->setKey("googleOAuth2ClientCredentials");
+	connect(readGoogleOAuth2ClientCredentialsJob, &QKeychain::Job::finished, this,
+		&AuthStore::onReadGoogleOAuth2ClientCredentialsFinished);
+	readGoogleOAuth2ClientCredentialsJob->start();
+
+	auto readGoogleTokenStateJob = new QKeychain::ReadPasswordJob(kKeychainService, this);
+	readGoogleTokenStateJob->setAutoDelete(true);
+	readGoogleTokenStateJob->setKey("googleTokenState");
+	connect(readGoogleTokenStateJob, &QKeychain::Job::finished, this, &AuthStore::onReadGoogleTokenStateFinished);
+	readGoogleTokenStateJob->start();
+}
+
+void AuthStore::onReadGoogleOAuth2ClientCredentialsFinished(QKeychain::Job *job)
+{
+	auto readJob = static_cast<QKeychain::ReadPasswordJob *>(job);
+
+	if (readJob->error() == QKeychain::Error::EntryNotFound) {
+		if (logger_) {
+			logger_->info("NoGoogleOAuth2ClientCredentialsInKeychain");
+		}
+	} else if (readJob->error()) {
+		if (logger_) {
+			std::string error = readJob->errorString().toStdString();
+			logger_->error("KeychainReadError", {{"error", error}});
+		}
 		return;
 	}
 
-	std::ifstream ifs(configPath, std::ios::in);
-	if (!ifs.is_open()) {
-		logger_->error("FileOpenError", {{"path", configPath.string()}});
-		throw std::runtime_error("FileOpenError(restore)");
-	}
-
-	nlohmann::json j;
-	ifs >> j;
-
-	std::scoped_lock lock(mutex_);
 	try {
-		if (j.contains("googleOAuth2ClientCredentials")) {
-			j.at("googleOAuth2ClientCredentials").get_to(googleOAuth2ClientCredentials_);
+		std::string jsonStr = readJob->textData().toStdString();
+		nlohmann::json j = nlohmann::json::parse(jsonStr);
+
+		std::scoped_lock lock(mutex_);
+		j.get_to(googleOAuth2ClientCredentials_);
+
+		if (logger_) {
 			logger_->info("RestoredGoogleOAuth2ClientCredentials");
 		}
-		if (j.contains("googleTokenState")) {
-			j.at("googleTokenState").get_to(googleTokenState_);
+	} catch (const std::exception &e) {
+		if (logger_) {
+			logger_->error("KeychainJsonParseError", {{"what", e.what()}});
+		}
+		googleOAuth2ClientCredentials_ = {};
+	} catch (...) {
+		if (logger_) {
+			logger_->error("KeychainUnknownError");
+		}
+		googleOAuth2ClientCredentials_ = {};
+	}
+}
+
+void AuthStore::onReadGoogleTokenStateFinished(QKeychain::Job *job)
+{
+	auto readJob = static_cast<QKeychain::ReadPasswordJob *>(job);
+
+	if (readJob->error() == QKeychain::Error::EntryNotFound) {
+		if (logger_) {
+			logger_->info("NoGoogleTokenStateInKeychain");
+		}
+	} else if (readJob->error()) {
+		if (logger_) {
+			std::string error = readJob->errorString().toStdString();
+			logger_->error("KeychainReadError", {{"error", error}});
+		}
+		return;
+	}
+
+	try {
+		std::string jsonStr = readJob->textData().toStdString();
+		nlohmann::json j = nlohmann::json::parse(jsonStr);
+
+		std::scoped_lock lock(mutex_);
+		j.get_to(googleTokenState_);
+		googleTokenState_.access_token.clear();
+
+		if (logger_) {
 			logger_->info("RestoredGoogleTokenState");
 		}
-	} catch (...) {
-		googleOAuth2ClientCredentials_ = {};
+	} catch (const std::exception &e) {
+		if (logger_) {
+			logger_->error("KeychainJsonParseError", {{"what", e.what()}});
+		}
 		googleTokenState_ = {};
-		throw;
+	} catch (...) {
+		if (logger_) {
+			logger_->error("KeychainUnknownError");
+		}
+		googleTokenState_ = {};
 	}
 }
 

--- a/src/LiveStreamSegmenter/Store/CMakeLists.txt
+++ b/src/LiveStreamSegmenter/Store/CMakeLists.txt
@@ -2,9 +2,18 @@ add_library(${CMAKE_PROJECT_NAME}_Store OBJECT)
 target_include_directories(${CMAKE_PROJECT_NAME}_Store PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
   ${CMAKE_PROJECT_NAME}_Store
-  PUBLIC OBS::libobs OBS::obs-frontend-api Logger GoogleAuth ObsBridgeUtils YouTubeApi
+  PUBLIC
+    OBS::libobs
+    OBS::obs-frontend-api
+    Qt6::Core
+    Qt6Keychain::Qt6Keychain
+    Logger
+    GoogleAuth
+    ObsBridgeUtils
+    YouTubeApi
 )
 target_sources(
   ${CMAKE_PROJECT_NAME}_Store
   PRIVATE AuthStore.cpp AuthStore.hpp EventHandlerStore.cpp EventHandlerStore.hpp YouTubeStore.cpp YouTubeStore.hpp
 )
+set_target_properties(${CMAKE_PROJECT_NAME}_Store PROPERTIES AUTOMOC ON)


### PR DESCRIPTION
This pull request migrates the storage of authentication credentials and tokens in `AuthStore` from plain JSON files on disk to secure storage using the system keychain via `qtkeychain`. This improves the security of sensitive data and modernizes the codebase. The changes also update the build system to support these new dependencies and refactor the `AuthStore` class to integrate with Qt's object model.

Key changes:

### Secure storage migration

* Replaced file-based storage of `GoogleOAuth2ClientCredentials` and `GoogleTokenState` in `AuthStore` with secure storage using `qtkeychain`, including new asynchronous read/write methods and error handling/logging for keychain operations. (`src/LiveStreamSegmenter/Store/AuthStore.cpp` [[1]](diffhunk://#diff-14dc78312e45f9301e412eb8daa38a9ba24863f6c585491b4c2377c7fdb60675L79-L82) [[2]](diffhunk://#diff-14dc78312e45f9301e412eb8daa38a9ba24863f6c585491b4c2377c7fdb60675L91-L147); `src/LiveStreamSegmenter/Store/AuthStore.hpp` [[3]](diffhunk://#diff-ebe05be30145b5a891a34e7a05744bfec445eb4a1224b464f973580ada708e5cR27-R43) [[4]](diffhunk://#diff-ebe05be30145b5a891a34e7a05744bfec445eb4a1224b464f973580ada708e5cL44-L65)

### Refactoring and Qt integration

* Refactored `AuthStore` to inherit from `QObject`, added Qt slots for handling keychain job results, and removed obsolete file path methods. (`src/LiveStreamSegmenter/Store/AuthStore.cpp` [[1]](diffhunk://#diff-14dc78312e45f9301e412eb8daa38a9ba24863f6c585491b4c2377c7fdb60675L34-R45); `src/LiveStreamSegmenter/Store/AuthStore.hpp` [[2]](diffhunk://#diff-ebe05be30145b5a891a34e7a05744bfec445eb4a1224b464f973580ada708e5cR27-R43) [[3]](diffhunk://#diff-ebe05be30145b5a891a34e7a05744bfec445eb4a1224b464f973580ada708e5cL44-L65)

### Build system updates

* Updated `CMakeLists.txt` to link against `Qt6::Core` and `Qt6Keychain::Qt6Keychain`, and enabled `AUTOMOC` for Qt meta-object compilation. (`src/LiveStreamSegmenter/Store/CMakeLists.txt` [src/LiveStreamSegmenter/Store/CMakeLists.txtL5-R19](diffhunk://#diff-0b93a80d723d0ae3c1a7ef07d74befd5dc42be8b5adf762979e17057813581dbL5-R19))

### Bundle identifier update

* Changed the macOS bundle identifier to `tokyo.kaito.live-stream-segmenter` for consistency with the new secure storage service name. (`buildspec.json` [buildspec.jsonL36-R36](diffhunk://#diff-d377ff3be1e2b9fd31f995cedd4b8d7a4b9f64a9e7493b7004e30ef7fc309b99L36-R36))Refactors AuthStore to store Google OAuth2 credentials and token state in the OS keychain using QtKeychain, replacing file-based storage. Updates the class to inherit from QObject, adds async keychain read/write logic, and updates CMake to link against Qt6Keychain. Also updates the macOS bundleId in buildspec.json.