### PR TITLE
Improve YouTube session segmentation logging and error handling

### DIFF
--- a/src/LiveStreamSegmenter/Controller/ProfileContext.cpp
+++ b/src/LiveStreamSegmenter/Controller/ProfileContext.cpp
@@ -75,7 +75,7 @@ ProfileContext::ProfileContext(std::shared_ptr<Scripting::ScriptingRuntime> runt
 
 	youTubeStreamSegmenterMainLoop_->startMainLoop();
 	youTubeStreamSegmenterMainLoop_->setTickTimerInterval(1000);
-	youTubeStreamSegmenterMainLoop_->setSegmentTimerInterval(120000);
+	youTubeStreamSegmenterMainLoop_->setSegmentTimerInterval(60000);
 }
 
 ProfileContext::~ProfileContext() noexcept = default;

--- a/src/LiveStreamSegmenter/UI/StreamSegmenterDock.cpp
+++ b/src/LiveStreamSegmenter/UI/StreamSegmenterDock.cpp
@@ -333,7 +333,7 @@ void StreamSegmenterDock::logMessage([[maybe_unused]] int level, const QString &
 		}
 	}
 
-	if (name == "YouTubeLiveBroadcastCreatedInitial") {
+	if (name == "YouTubeLiveBroadcastCreatedInitial" || name == "ContinuousYouTubeSessionSegmented") {
 		QString title = context.value("title");
 		QString broadcastId = context.value("broadcastId");
 		currentTitleLabel_->setText(title.isEmpty() ? tr("(No title)") : title);


### PR DESCRIPTION
This pull request updates the YouTube live stream segmenter to improve logging clarity and error handling, as well as refines the UI to better display broadcast information. The main changes include more descriptive log messages, additional error checks for broadcast data, and a reduced segment timer interval.

**Logging improvements:**

* Updated log messages in `YouTubeStreamSegmenterMainLoop::segmentContinuousSessionTask` to use "Incoming" instead of "Switching" for live stream events, improving clarity. [[1]](diffhunk://#diff-2c49afda626983ec88f84f379f6e351a583a0548b669c3cf93cb8775ba652bb1L728-R729) [[2]](diffhunk://#diff-2c49afda626983ec88f84f379f6e351a583a0548b669c3cf93cb8775ba652bb1L743-R743)
* Added detailed logging of broadcast ID and title after segment completion, and enhanced error handling to log and throw if critical broadcast information is missing.

**UI enhancements:**

* Modified `StreamSegmenterDock::logMessage` to update the UI with broadcast title and ID when either an initial broadcast is created or a session segment is completed.

**Timer adjustment:**

* Changed the segment timer interval in `ProfileContext` from 120,000ms to 60,000ms, reducing the time between segments.Changed segment timer interval from 120000ms to 60000ms in ProfileContext. Updated log messages in YouTubeStreamSegmenterMainLoop for clarity and added error handling for missing broadcast ID or title. UI now updates the current title label for both initial and segmented YouTube broadcasts.