### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,13 +234,6 @@ if(NOT Qt6Keychain_FOUND)
 endif()
 
 if(TARGET qt6keychain)
-  if(APPLE)
-    target_compile_options(qt6keychain PRIVATE -Wno-quoted-include-in-framework-header -fno-objc-arc)
-  elseif(MSVC)
-  else()
-    target_compile_options(qt6keychain PRIVATE -Wno-cast-function-type)
-  endif()
-
   add_library(Qt6Keychain::Qt6Keychain ALIAS qt6keychain)
 endif()
 


### PR DESCRIPTION
This pull request removes platform-specific compiler options for the `qt6keychain` target from the `CMakeLists.txt` file. The configuration is now simplified and no longer sets special compile flags for Apple or other platforms.

Build configuration simplification:

* Removed conditional logic that added platform-specific compiler options (`-Wno-quoted-include-in-framework-header`, `-fno-objc-arc`, `-Wno-cast-function-type`) for the `qt6keychain` target, making the build configuration cleaner and less error-prone.