### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ if(NOT Qt6Keychain_FOUND)
   message(FATAL_ERROR "Qt6Keychain not found.")
 endif()
 
-if(TARGET qt6keychain)
+if(TARGET qt6keychain AND NOT TARGET Qt6Keychain::Qt6Keychain)
   add_library(Qt6Keychain::Qt6Keychain ALIAS qt6keychain)
 endif()
 


### PR DESCRIPTION
This pull request makes a small adjustment to the `CMakeLists.txt` file to improve the logic for creating an alias target for `Qt6Keychain`. The change ensures that the alias is only created if it does not already exist.

* Only create the `Qt6Keychain::Qt6Keychain` alias for the `qt6keychain` target if it doesn't already exist, preventing duplicate alias definitions.