### PR TITLE
Update init.cmake

### DIFF
--- a/cmake/common/init.cmake
+++ b/cmake/common/init.cmake
@@ -28,14 +28,6 @@ set(
   ""
 )
 
-set(
-  CMAKE_MAP_IMPORTED_CONFIG_DEBUG
-  Debug
-  None
-  Noconfig
-  ""
-)
-
 set(BUILDSPEC_FILE "${CMAKE_CURRENT_SOURCE_DIR}/buildspec.json")
 
 if(EXISTS "${BUILDSPEC_FILE}")


### PR DESCRIPTION
This pull request makes a minor change to the CMake build initialization by removing custom configuration mapping settings. These mappings are no longer needed and their removal helps simplify the build configuration.

* Removed the `CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO`, `CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL`, and `CMAKE_MAP_IMPORTED_CONFIG_RELEASE` variables from `cmake/common/init.cmake`, simplifying the configuration mapping logic.