### PR TITLE
Update YouTubeStreamSegmenterWorker.cpp

### DIFF
--- a/src/LiveStreamSegmenter/Controller/YouTubeStreamSegmenterWorker.cpp
+++ b/src/LiveStreamSegmenter/Controller/YouTubeStreamSegmenterWorker.cpp
@@ -729,6 +729,8 @@ QCoro::Task<> YouTubeStreamSegmenterWorker::onSegmentSession()
 		taskLogger->info("OBSStreamingEnsuredStopped");
 
 		// --- Start streaming the initial live broadcast ---
+		co_await QCoro::moveToThread(mainContext_->thread());
+
 		taskLogger->info("StreamingStarting");
 
 		const auto incomingLiveBroadcast = liveBroadcasts_[1 - currentLiveStreamIndex_];


### PR DESCRIPTION
This pull request introduces a small but important change to the `YouTubeStreamSegmenterWorker::onStartSession()` method. The update ensures that the coroutine resumes execution on the main thread before starting the streaming process, which can help avoid threading issues and improve application stability.

- Thread management improvement:
  * Added `co_await QCoro::moveToThread(mainContext_->thread());` to ensure streaming setup occurs on the main thread in `YouTubeStreamSegmenterWorker.cpp`.