### PR TITLE
Fix crash when OBS without cef

### DIFF
--- a/src/LiveStreamSegmenter/Controller/YouTubeStreamSegmenterWorker.cpp
+++ b/src/LiveStreamSegmenter/Controller/YouTubeStreamSegmenterWorker.cpp
@@ -346,8 +346,8 @@ QCoro::Task<void> startStreaming(QThread *workerThread, Jthread::stop_token stok
 		obs_data_set_string(settings.get(), "server", "rtmps://a.rtmps.youtube.com:443/live2");
 		obs_data_set_string(settings.get(), "key", nextLiveStream->cdn.ingestionInfo.streamName.c_str());
 
-		obs_service_t *service =
-			obs_service_create("rtmp_common", "Live Stream Segmenter YouTube RTMP Service", settings.get(), nullptr);
+		obs_service_t *service = obs_service_create("rtmp_common", "Live Stream Segmenter YouTube RTMP Service",
+							    settings.get(), nullptr);
 
 		obs_frontend_set_streaming_service(service);
 		obs_service_release(service);
@@ -364,7 +364,8 @@ QCoro::Task<void> startStreaming(QThread *workerThread, Jthread::stop_token stok
 			"https://a.upload.youtube.com/http_upload_hls?cid={stream_key}&copy=0&file=out.m3u8");
 		obs_data_set_string(settings.get(), "key", nextLiveStream->cdn.ingestionInfo.streamName.c_str());
 
-		obs_service_t *service = obs_service_create("rtmp_common", "Live Stream Segmenter YouTube HLS Service", settings.get(), nullptr);
+		obs_service_t *service = obs_service_create("rtmp_common", "Live Stream Segmenter YouTube HLS Service",
+							    settings.get(), nullptr);
 
 		obs_frontend_set_streaming_service(service);
 		obs_service_release(service);


### PR DESCRIPTION
This pull request updates the way streaming services are configured for YouTube RTMP and HLS in the `YouTubeStreamSegmenterWorker`. The main improvements involve switching to a "Custom" service type and explicitly setting the streaming protocol, which should provide greater flexibility and clarity in service configuration.

**Streaming service configuration updates:**

* Changed the `service` setting from `"YouTube - RTMP"` and `"YouTube - HLS"` to `"Custom"` for both RTMP and HLS streams, and added explicit `protocol` settings (`"RTMPS"` for RTMP and `"HLS"` for HLS). [[1]](diffhunk://#diff-76dafcc9743f6b7a93c74f16b035a5e5f65669d98e0aacf9d11265d9db0ec8b7L344-R350) [[2]](diffhunk://#diff-76dafcc9743f6b7a93c74f16b035a5e5f65669d98e0aacf9d11265d9db0ec8b7L359-R367)
* Updated the service creation calls to use more descriptive names and replaced `NULL` with `nullptr` for better C++ style and type safety. [[1]](diffhunk://#diff-76dafcc9743f6b7a93c74f16b035a5e5f65669d98e0aacf9d11265d9db0ec8b7L344-R350) [[2]](diffhunk://#diff-76dafcc9743f6b7a93c74f16b035a5e5f65669d98e0aacf9d11265d9db0ec8b7L359-R367)