### PR TITLE
Add delays before YouTube broadcast transitions

### DIFF
--- a/src/LiveStreamSegmenter/Controller/YouTubeStreamSegmenterWorker.cpp
+++ b/src/LiveStreamSegmenter/Controller/YouTubeStreamSegmenterWorker.cpp
@@ -420,14 +420,19 @@ QCoro::Task<void> startStreaming(QThread *workerThread, Jthread::stop_token stok
 	logger->info("YouTubeLiveBroadcastTransitioningToTesting",
 		     {{"broadcastId", *nextLiveBroadcast->id}, {"title", nextLiveBroadcastTitle}});
 
+	// Wait a bit before transitioning to "testing"
+	co_await QCoro::sleepFor(5s);
+
 	youTubeApiClient->transitionLiveBroadcast(stoken, accessToken, *nextLiveBroadcast->id, "testing");
 
 	logger->info("YouTubeLiveBroadcastTransitionedToTesting",
 		     {{"broadcastId", *nextLiveBroadcast->id}, {"title", nextLiveBroadcastTitle}});
-	co_await QCoro::sleepFor(5s);
 
 	logger->info("YouTubeLiveBroadcastTransitioningToLive",
 		     {{"broadcastId", *nextLiveBroadcast->id}, {"title", nextLiveBroadcastTitle}});
+
+	// Wait a bit before transitioning to "live"
+	co_await QCoro::sleepFor(5s);
 
 	youTubeApiClient->transitionLiveBroadcast(stoken, accessToken, *nextLiveBroadcast->id, "live");
 


### PR DESCRIPTION
This pull request makes a small adjustment to the timing of state transitions in the YouTube live broadcast workflow. The main change is to introduce explicit delays before transitioning the broadcast to the "testing" and "live" states, ensuring the system waits the intended amount of time before each transition.

- Added a 5-second delay before transitioning a YouTube live broadcast to the "testing" state, and moved the existing delay to occur before the "live" transition instead of after the "testing" transition in `YouTubeStreamSegmenterWorker.cpp`.Inserted 5-second delays before transitioning broadcasts to 'testing' and 'live' states to ensure proper sequencing and stability during YouTube live stream state changes.