### PR TITLE
Update Astro, sitemap, and Prettier dependencies

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,9 +8,9 @@
       "name": "live-stream-segmenter-docs",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/sitemap": "^3.6.0",
+        "@astrojs/sitemap": "^3.7.0",
         "@octokit/rest": "^22.0.1",
-        "astro": "^5.16.4",
+        "astro": "^5.16.11",
         "monaco-editor": "^0.55.1",
         "posthtml": "^0.16.7",
         "pretty-bytes": "^7.1.0",
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "dayjs": "^1.11.19",
-        "prettier": "^3.7.4",
+        "prettier": "^3.8.0",
         "prettier-plugin-astro": "^0.14.1"
       },
       "engines": {
@@ -79,12 +79,12 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.6.0.tgz",
-      "integrity": "sha512-4aHkvcOZBWJigRmMIAJwRQXBS+ayoP5z40OklTXYXhUDhwusz+DyDl+nSshY6y9DvkVEavwNcFO8FD81iGhXjg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.0.tgz",
+      "integrity": "sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA==",
       "license": "MIT",
       "dependencies": {
-        "sitemap": "^8.0.0",
+        "sitemap": "^8.0.2",
         "stream-replace-string": "^2.0.0",
         "zod": "^3.25.76"
       }
@@ -154,21 +154,21 @@
       }
     },
     "node_modules/@capsizecss/unpack": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-3.0.1.tgz",
-      "integrity": "sha512-8XqW8xGn++Eqqbz3e9wKuK7mxryeRjs4LOHLxbh2lwKeSbuNR4NFifDZT4KzvjU6HMOPbiNTsWpniK5EJfTWkg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
+      "integrity": "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==",
       "license": "MIT",
       "dependencies": {
-        "fontkit": "^2.0.2"
+        "fontkitten": "^1.0.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1605,15 +1605,6 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1628,15 +1619,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
-    },
-    "node_modules/@types/fontkit": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/fontkit/-/fontkit-2.0.8.tgz",
-      "integrity": "sha512-wN+8bYxIpJf+5oZdrdtaX04qUuWHcKxcDEgRS9Qm9ZClSHjzEn13SxUC+5eRM+4yXIeTYk8mTzLAWGF64847ew==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -1851,16 +1833,16 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.16.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.6.tgz",
-      "integrity": "sha512-6mF/YrvwwRxLTu+aMEa5pwzKUNl5ZetWbTyZCs9Um0F12HUmxUiF5UHiZPy4rifzU3gtpM3xP2DfdmkNX9eZRg==",
+      "version": "5.16.11",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.11.tgz",
+      "integrity": "sha512-Z7kvkTTT5n6Hn5lCm6T3WU6pkxx84Hn25dtQ6dR7ATrBGq9eVa8EuB/h1S8xvaoVyCMZnIESu99Z9RJfdLRLDA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
         "@astrojs/markdown-remark": "6.3.10",
         "@astrojs/telemetry": "3.3.0",
-        "@capsizecss/unpack": "^3.0.1",
+        "@capsizecss/unpack": "^4.0.0",
         "@oslojs/encoding": "^1.1.0",
         "@rollup/pluginutils": "^5.3.0",
         "acorn": "^8.15.0",
@@ -1870,19 +1852,19 @@
         "ci-info": "^4.3.1",
         "clsx": "^2.1.1",
         "common-ancestor-path": "^1.0.1",
-        "cookie": "^1.0.2",
+        "cookie": "^1.1.1",
         "cssesc": "^3.0.0",
         "debug": "^4.4.3",
         "deterministic-object-hash": "^2.0.2",
-        "devalue": "^5.5.0",
-        "diff": "^5.2.0",
+        "devalue": "^5.6.2",
+        "diff": "^8.0.3",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^1.7.0",
         "esbuild": "^0.25.0",
         "estree-walker": "^3.0.3",
         "flattie": "^1.1.1",
-        "fontace": "~0.3.1",
+        "fontace": "~0.4.0",
         "github-slugger": "^2.0.0",
         "html-escaper": "3.0.3",
         "http-cache-semantics": "^4.2.0",
@@ -1894,20 +1876,20 @@
         "neotraverse": "^0.6.18",
         "p-limit": "^6.2.0",
         "p-queue": "^8.1.1",
-        "package-manager-detector": "^1.5.0",
+        "package-manager-detector": "^1.6.0",
         "piccolore": "^0.1.3",
         "picomatch": "^4.0.3",
         "prompts": "^2.4.2",
         "rehype": "^13.0.2",
         "semver": "^7.7.3",
-        "shiki": "^3.15.0",
-        "smol-toml": "^1.5.2",
+        "shiki": "^3.20.0",
+        "smol-toml": "^1.6.0",
         "svgo": "^4.0.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
         "tsconfck": "^3.1.6",
         "ultrahtml": "^1.6.0",
-        "unifont": "~0.6.0",
+        "unifont": "~0.7.1",
         "unist-util-visit": "^5.0.0",
         "unstorage": "^1.17.3",
         "vfile": "^6.0.3",
@@ -1917,7 +1899,7 @@
         "yargs-parser": "^21.1.1",
         "yocto-spinner": "^0.2.3",
         "zod": "^3.25.76",
-        "zod-to-json-schema": "^3.25.0",
+        "zod-to-json-schema": "^3.25.1",
         "zod-to-ts": "^1.2.0"
       },
       "bin": {
@@ -1961,26 +1943,6 @@
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -2013,15 +1975,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/brotli": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
-      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.1.2"
       }
     },
     "node_modules/camelcase": {
@@ -2128,15 +2081,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/clsx": {
@@ -2423,9 +2367,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.1.tgz",
-      "integrity": "sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
+      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -2441,16 +2385,10 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dfa": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
-      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
-      "license": "MIT"
-    },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -2658,12 +2596,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2691,30 +2623,24 @@
       }
     },
     "node_modules/fontace": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.3.1.tgz",
-      "integrity": "sha512-9f5g4feWT1jWT8+SbL85aLIRLIXUaDygaM2xPXRmzPYxrOMNok79Lr3FGJoKVNKibE0WCunNiEVG2mwuE+2qEg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.0.tgz",
+      "integrity": "sha512-moThBCItUe2bjZip5PF/iZClpKHGLwMvR79Kp8XpGRBrvoRSnySN4VcILdv3/MJzbhvUA5WeiUXF5o538m5fvg==",
       "license": "MIT",
       "dependencies": {
-        "@types/fontkit": "^2.0.8",
-        "fontkit": "^2.0.4"
+        "fontkitten": "^1.0.0"
       }
     },
-    "node_modules/fontkit": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
-      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+    "node_modules/fontkitten": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.2.tgz",
+      "integrity": "sha512-piJxbLnkD9Xcyi7dWJRnqszEURixe7CrF/efBfbffe2DPyabmuIuqraruY8cXTs19QoM8VJzx47BDRVNXETM7Q==",
       "license": "MIT",
       "dependencies": {
-        "@swc/helpers": "^0.5.12",
-        "brotli": "^1.3.2",
-        "clone": "^2.1.2",
-        "dfa": "^1.2.0",
-        "fast-deep-equal": "^3.1.3",
-        "restructure": "^3.0.0",
-        "tiny-inflate": "^1.0.3",
-        "unicode-properties": "^1.4.0",
-        "unicode-trie": "^2.0.0"
+        "tiny-inflate": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/fsevents": {
@@ -4144,12 +4070,6 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
-    "node_modules/pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
-      "license": "MIT"
-    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -4270,9 +4190,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
+      "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4529,12 +4449,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/restructure": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
-      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
-      "license": "MIT"
-    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -4766,9 +4680,9 @@
       "license": "MIT"
     },
     "node_modules/smol-toml": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
-      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -4958,7 +4872,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-fest": {
       "version": "4.41.0",
@@ -5010,26 +4925,6 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
-    "node_modules/unicode-properties": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
-      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "unicode-trie": "^2.0.0"
-      }
-    },
-    "node_modules/unicode-trie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
-      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "pako": "^0.2.5",
-        "tiny-inflate": "^1.0.0"
-      }
-    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -5050,14 +4945,14 @@
       }
     },
     "node_modules/unifont": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.6.0.tgz",
-      "integrity": "sha512-5Fx50fFQMQL5aeHyWnZX9122sSLckcDvcfFiBf3QYeHa7a1MKJooUy52b67moi2MJYkrfo/TWY+CoLdr/w0tTA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.3.tgz",
+      "integrity": "sha512-b0GtQzKCyuSHGsfj5vyN8st7muZ6VCI4XD4vFlr7Uy1rlWVYxC3npnfk8MyreHxJYrz1ooLDqDzFe9XqQTlAhA==",
       "license": "MIT",
       "dependencies": {
-        "css-tree": "^3.0.0",
-        "ofetch": "^1.4.1",
-        "ohash": "^2.0.0"
+        "css-tree": "^3.1.0",
+        "ofetch": "^1.5.1",
+        "ohash": "^2.0.11"
       }
     },
     "node_modules/unist-util-find-after": {
@@ -5537,9 +5432,9 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
-      "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,9 +13,9 @@
     "node": "24.x"
   },
   "dependencies": {
-    "@astrojs/sitemap": "^3.6.0",
+    "@astrojs/sitemap": "^3.7.0",
     "@octokit/rest": "^22.0.1",
-    "astro": "^5.16.4",
+    "astro": "^5.16.11",
     "monaco-editor": "^0.55.1",
     "posthtml": "^0.16.7",
     "pretty-bytes": "^7.1.0",
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "dayjs": "^1.11.19",
-    "prettier": "^3.7.4",
+    "prettier": "^3.8.0",
     "prettier-plugin-astro": "^0.14.1"
   }
 }


### PR DESCRIPTION
This pull request updates the dependencies in the `docs/package-lock.json` file, primarily upgrading several core and development packages and cleaning up unused or replaced dependencies. The changes ensure compatibility with newer versions, improve performance, and reduce potential security risks by removing outdated packages. Notably, there are significant updates to font-related packages, and several obsolete dependencies have been removed as a result.

Dependency upgrades:

* Upgraded core dependencies including `astro` (to 5.16.11), `@astrojs/sitemap` (to 3.7.0), and `prettier` (to 3.8.0), along with various other minor and patch-level upgrades for packages like `devalue`, `diff`, `smol-toml`, `shiki`, and `zod-to-json-schema`. [[1]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L11-R21) [[2]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L82-R87) [[3]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L1854-R1845) [[4]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L1873-R1867) [[5]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L1897-R1892) [[6]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L1920-R1902) [[7]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L2426-R2372) [[8]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L4273-R4195) [[9]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L4769-R4685) [[10]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L5540-R5437)

Font and asset handling changes:

* Replaced `fontkit` and related dependencies (`@types/fontkit`, `unicode-properties`, `unicode-trie`, `restructure`, etc.) with the new `fontkitten` package, and upgraded `fontace` and `@capsizecss/unpack` to use this new stack. This also led to the removal of several now-unnecessary font-related dependencies. [[1]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L157-R171) [[2]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L1632-L1640) [[3]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L2694-R2643) [[4]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L5013-L5032)

Removed unused or obsolete dependencies:

* Removed various unused or replaced packages such as `@swc/helpers`, `base64-js`, `brotli`, `clone`, `dfa`, `fast-deep-equal`, `pako`, and others that are no longer needed due to dependency upgrades or architectural changes. [[1]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L1608-L1616) [[2]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L1964-L1983) [[3]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L2018-L2026) [[4]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L2133-L2141) [[5]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L2444-R2391) [[6]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L2661-L2666) [[7]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L4147-L4152) [[8]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L4532-L4537) [[9]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L5013-L5032)

Other dependency updates:

* Upgraded additional dependencies for improved compatibility and bug fixes, such as `unifont`, `cookie`, `package-manager-detector`, and others. [[1]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L1873-R1867) [[2]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L5053-R4955)

Minor metadata and housekeeping:

* Adjusted license and engine fields for some dependencies and marked certain packages (like `tslib`) as optional where appropriate.Bump versions of 'astro', '@astrojs/sitemap', and 'prettier' in docs/package.json and package-lock.json. This also updates related transitive dependencies to their latest compatible versions for improved stability and features.